### PR TITLE
[MW-193] Modify ffmpeg conversion params

### DIFF
--- a/MojeWidelo_WebApi/Controllers/VideoController.cs
+++ b/MojeWidelo_WebApi/Controllers/VideoController.cs
@@ -160,6 +160,7 @@ namespace MojeWidelo_WebApi.Controllers
 			if (
 				video.ProcessingProgress != ProcessingProgress.MetadataRecordCreated
 				&& video.ProcessingProgress != ProcessingProgress.FailedToUpload
+				&& video.ProcessingProgress != ProcessingProgress.FailedToProcess
 			)
 				return StatusCode(
 					StatusCodes.Status400BadRequest,

--- a/Repository/VideoRepository.cs
+++ b/Repository/VideoRepository.cs
@@ -62,7 +62,28 @@ namespace Repository
 
 				await ChangeVideoProcessingProgress(id, ProcessingProgress.Processing);
 
-				await Cli.Wrap("ffmpeg").WithArguments(new[] { "-i", path, newPath }).ExecuteBufferedAsync();
+				await Cli.Wrap("ffmpeg")
+					.WithArguments(
+						new[]
+						{
+							"-i",
+							path,
+							"-map_metadata",
+							"-1",
+							"-c:v",
+							"libx264",
+							"-preset",
+							"faster",
+							"-crf",
+							"30",
+							"-c:a",
+							"ac3",
+							"-b:a",
+							"128k",
+							newPath
+						}
+					)
+					.ExecuteBufferedAsync();
 
 				if (!System.IO.File.Exists(newPath))
 					throw new Exception("After successful conversion, output file does not exist!");


### PR DESCRIPTION
Zmiana paremtrów dla przetwarzania wideo:
- usunięcie całej metadaty
- zmiana trybu przetwarzania wideo na szybszy
- wideo będzie w H.264 (zawsze)
- obniżenie bitrate wideo
- audio będzie zawsze w AC3 i 128Kbps

Zanotowane zyski:
- przetwarzanie krótsze o ~20%
- pliki mniejsze o ~50%
- spadek jakości - do przeżycia

Dokumentacja dla ciekawych:
- https://trac.ffmpeg.org/wiki/Encode/H.264
- https://trac.ffmpeg.org/wiki/Encode/HighQualityAudio

Dodatkowe zmiany:
- dodanie stanu ProcessingState.FailedToProcess jako stanu pozwalającego na upload

Testy:
- Postman -> saj -> upload video