### PR TITLE
[MW-196] Implement adding duration to VideoMetadata after successful processing

### DIFF
--- a/Contracts/IVideoRepository.cs
+++ b/Contracts/IVideoRepository.cs
@@ -8,7 +8,7 @@ namespace Contracts
 	public interface IVideoRepository : IRepositoryBase<VideoMetadata>
 	{
 		Task ChangeVideoProcessingProgress(string id, ProcessingProgress uploading);
-		void ProccessVideoFile(string id, string path);
+		Task ProccessVideoFile(string id, string path);
 		Task<string> UploadThumbnail(string file);
 		Task SetThumbnail(HttpContext httpContext, VideoMetadata video, VideoBaseDto videoDto);
 		Task<byte[]> GetThumbnailBytes(string id);
@@ -18,5 +18,7 @@ namespace Contracts
 		Task<IEnumerable<VideoMetadata>> GetVideos(IEnumerable<string> videosIDs, string userID);
 		Task<IEnumerable<VideoMetadata>> GetAllVisibleVideos(string userId);
 		Task<VideoMetadata> UpdateViewCount(string id, int value);
+		Task<string> GetDuration(string id);
+		Task UpdateVideoDuration(string id, string duration);
 	}
 }

--- a/Contracts/IVideoRepository.cs
+++ b/Contracts/IVideoRepository.cs
@@ -20,5 +20,6 @@ namespace Contracts
 		Task<VideoMetadata> UpdateViewCount(string id, int value);
 		Task<string> GetDuration(string id);
 		Task UpdateVideoDuration(string id, string duration);
+		Task ProcessAndAddDuration(string id, string path);
 	}
 }

--- a/MojeWidelo_WebApi/Controllers/VideoController.cs
+++ b/MojeWidelo_WebApi/Controllers/VideoController.cs
@@ -192,7 +192,12 @@ namespace MojeWidelo_WebApi.Controllers
 
 			await _repository.VideoRepository.ChangeVideoProcessingProgress(id, ProcessingProgress.Uploaded);
 
-			Thread t = new Thread(() => _repository.VideoRepository.ProccessVideoFile(id, path));
+			Thread t = new Thread(async () =>
+			{
+				await _repository.VideoRepository.ProccessVideoFile(id, path);
+				string duration = await _repository.VideoRepository.GetDuration(id);
+				await _repository.VideoRepository.UpdateVideoDuration(id, duration);
+			});
 			t.Start();
 
 			return StatusCode(StatusCodes.Status200OK, "Przesyłanie zakończone pomyślnie.");

--- a/MojeWidelo_WebApi/Controllers/VideoController.cs
+++ b/MojeWidelo_WebApi/Controllers/VideoController.cs
@@ -192,12 +192,7 @@ namespace MojeWidelo_WebApi.Controllers
 
 			await _repository.VideoRepository.ChangeVideoProcessingProgress(id, ProcessingProgress.Uploaded);
 
-			Thread t = new Thread(async () =>
-			{
-				await _repository.VideoRepository.ProccessVideoFile(id, path);
-				string duration = await _repository.VideoRepository.GetDuration(id);
-				await _repository.VideoRepository.UpdateVideoDuration(id, duration);
-			});
+			Thread t = new Thread(() => _repository.VideoRepository.ProcessAndAddDuration(id, path));
 			t.Start();
 
 			return StatusCode(StatusCodes.Status200OK, "Przesyłanie zakończone pomyślnie.");

--- a/Repository/VideoRepository.cs
+++ b/Repository/VideoRepository.cs
@@ -221,5 +221,12 @@ namespace Repository
 			var update = Builders<VideoMetadata>.Update.Set(v => v.Duration, duration);
 			await Collection.UpdateOneAsync(v => v.Id == id, update);
 		}
+
+		public async Task ProcessAndAddDuration(string id, string path)
+		{
+			await ProccessVideoFile(id, path);
+			string duration = await GetDuration(id);
+			await UpdateVideoDuration(id, duration);
+		}
 	}
 }

--- a/Repository/VideoRepository.cs
+++ b/Repository/VideoRepository.cs
@@ -10,6 +10,7 @@ using MongoDB.Bson;
 using MongoDB.Driver;
 using MongoDB.Driver.GridFS;
 using Repository.Managers;
+using System.Text.RegularExpressions;
 
 namespace Repository
 {
@@ -41,7 +42,7 @@ namespace Repository
 			);
 		}
 
-		public async void ProccessVideoFile(string id, string path)
+		public async Task ProccessVideoFile(string id, string path)
 		{
 			try
 			{
@@ -196,6 +197,29 @@ namespace Repository
 			var update = Builders<VideoMetadata>.Update.Inc(u => u.ViewCount, value);
 			await Collection.UpdateOneAsync(video => video.Id == id, update);
 			return await GetById(id);
+		}
+
+		public async Task<string> GetDuration(string id)
+		{
+			string newPath = videoManager.GetReadyFilePath(id)!;
+			BufferedCommandResult? result = await Cli.Wrap("ffmpeg")
+				.WithArguments(new[] { "-i", newPath })
+				.WithValidation(CommandResultValidation.None)
+				.ExecuteBufferedAsync();
+
+			List<string> splitted = result.StandardError.Split(' ', StringSplitOptions.RemoveEmptyEntries).ToList();
+			splitted.RemoveAll(x => !Regex.IsMatch(x, @"\d*\d\d:\d\d:\d\d.\d\d"));
+
+			if (splitted.Count != 1)
+				return String.Empty;
+
+			return splitted[0].TrimEnd(',');
+		}
+
+		public async Task UpdateVideoDuration(string id, string duration)
+		{
+			var update = Builders<VideoMetadata>.Update.Set(v => v.Duration, duration);
+			await Collection.UpdateOneAsync(v => v.Id == id, update);
 		}
 	}
 }


### PR DESCRIPTION
Po zakończeniu powodzeniem przetwarzania wideo, dodawane jest pole duration do VideoMetadata (wcześniej był tam null)

Problem próbowałem rozwiązać przy pomocy nugetów, lecz żaden z dostępnych nie zapewnia przenośności na systemy UNIXowe.
Z tego też powodu, postanowiłem ponownie użyć (niezgodnie z przeznaczniem) programu ffmpeg oraz wyłuskać wartość duration przy pomocy REGEXu.

Testowanie:
Postman -> saj -> {POST videoMetadata; GET videometadata (duration jest null'em); POST video/{id}; GET videometadata (jeżeli stan video jest ustawiony na Ready, duration jest poprawnie uzupełniona);};