### PR TITLE
MW-215 Add HTTP compression for serving HTML, CSS, JS

### DIFF
--- a/MojeWidelo_WebApi/Program.cs
+++ b/MojeWidelo_WebApi/Program.cs
@@ -16,6 +16,11 @@ builder.Services.ConfigureServices();
 builder.Services.ConfigureManagers();
 builder.Services.ConfigureVariables(builder.Configuration);
 builder.Services.ConfigureDateOnlyTimeOnlyConverters();
+builder.Services.AddResponseCompression(options =>
+{
+	options.EnableForHttps = true;
+	options.MimeTypes = new[] { "text/html", "application/javascript", "text/css" };
+});
 
 #endregion
 
@@ -40,6 +45,7 @@ if (app.Environment.IsDevelopment())
 }
 
 app.UseCors("EnableCORS");
+app.UseResponseCompression();
 
 RewriteOptions rewriteHttps = new RewriteOptions().AddRedirectToHttpsPermanent();
 app.UseRewriter(rewriteHttps);


### PR DESCRIPTION
Optimize serving frontend files:

Before: 
![image](https://github.com/IO2-2023-JB/team-10-backend/assets/92390086/fff3f09b-1b2d-4048-9560-9e792a57afaa)
HTML + CSS + JS (main module) = about 580 kB, 3.8s on fast 3G

After:
![image](https://github.com/IO2-2023-JB/team-10-backend/assets/92390086/82987864-2601-44e0-9282-8db362652684)
HTML + CSS + JS (main module) = about 240 kB, 1.9s on fast 3G

Compression is only enabled for static files which do not contain any secret user data, because of CRIME and BREACH attacks (compression in HTTPS is a security risk): https://learn.microsoft.com/en-us/aspnet/core/performance/response-compression?view=aspnetcore-7.0#risk