### PR TITLE
Mw 226/watch history

### DIFF
--- a/Contracts/IHistoryRepository.cs
+++ b/Contracts/IHistoryRepository.cs
@@ -1,0 +1,9 @@
+﻿using Entities.Models;
+
+namespace Contracts
+{
+	public interface IHistoryRepository : IRepositoryBase<History>
+	{
+		Task AddToHistory(string userId, string videoId);
+	}
+}

--- a/Contracts/IHistoryRepository.cs
+++ b/Contracts/IHistoryRepository.cs
@@ -2,7 +2,7 @@
 
 namespace Contracts
 {
-	public interface IHistoryRepository : IRepositoryBase<History>
+	public interface IHistoryRepository : IRepositoryBase<UserHistory>
 	{
 		Task AddToHistory(string userId, string videoId);
 	}

--- a/Contracts/IRepositoryWrapper.cs
+++ b/Contracts/IRepositoryWrapper.cs
@@ -8,5 +8,6 @@
 		ICommentRepository CommentRepository { get; }
 		ISubscriptionsRepository SubscriptionsRepository { get; }
 		IPlaylistRepository PlaylistRepository { get; }
+		IHistoryRepository HistoryRepository { get; }
 	}
 }

--- a/Entities/Models/History.cs
+++ b/Entities/Models/History.cs
@@ -7,11 +7,11 @@ namespace Entities.Models
 	/// Obiekt historii oglądania filmów przez użytkownika
 	/// Id historii == Id usera
 	/// </summary>
-	public class History : MongoDocumentBase
+	public class UserHistory : MongoDocumentBase
 	{
 		public IEnumerable<HistoryItem> WatchedVideos { get; set; }
 
-		public History(string userId)
+		public UserHistory(string userId)
 		{
 			Id = userId;
 			WatchedVideos = new List<HistoryItem>();

--- a/Entities/Models/History.cs
+++ b/Entities/Models/History.cs
@@ -1,0 +1,34 @@
+﻿using MongoDB.Bson;
+using MongoDB.Bson.Serialization.Attributes;
+
+namespace Entities.Models
+{
+	/// <summary>
+	/// Obiekt historii oglądania filmów przez użytkownika
+	/// Id historii == Id usera
+	/// </summary>
+	public class History : MongoDocumentBase
+	{
+		public IEnumerable<HistoryItem> WatchedVideos { get; set; }
+
+		public History(string userId)
+		{
+			Id = userId;
+			WatchedVideos = new List<HistoryItem>();
+		}
+	}
+
+	public class HistoryItem
+	{
+		public HistoryItem(string videoId)
+		{
+			VideoId = videoId;
+			Date = DateTime.Now;
+		}
+
+		[BsonRepresentation(BsonType.ObjectId)]
+		public string VideoId { get; set; }
+
+		public DateTime Date { get; set; }
+	}
+}

--- a/Entities/Utils/DatabaseSettings.cs
+++ b/Entities/Utils/DatabaseSettings.cs
@@ -10,5 +10,6 @@
 		public string CommentCollectionName { get; set; }
 		public string SubscriptionCollectionName { get; set; }
 		public string PlaylistCollectionName { get; set; }
+		public string HistoryCollectionName { get; set; }
 	}
 }

--- a/Entities/Utils/IDatabaseSettings.cs
+++ b/Entities/Utils/IDatabaseSettings.cs
@@ -6,13 +6,13 @@
 		string ConnectionString { get; set; }
 
 		#region Collections
-
 		string UsersCollectionName { get; set; }
 		string VideoCollectionName { get; set; }
 		string ReactionCollectionName { get; set; }
 		string CommentCollectionName { get; set; }
 		string SubscriptionCollectionName { get; set; }
 		string PlaylistCollectionName { get; set; }
+		string HistoryCollectionName { get; set; }
 		#endregion
 	}
 }

--- a/MojeWidelo_WebApi.UnitTests/Mocks/MockIHistoryRepository.cs
+++ b/MojeWidelo_WebApi.UnitTests/Mocks/MockIHistoryRepository.cs
@@ -4,11 +4,11 @@ using Moq;
 
 namespace MojeWidelo_WebApi.UnitTests.Mocks
 {
-	public class MockIHistoryRepository : MockIRepositoryBase<IHistoryRepository, History>
+	public class MockIHistoryRepository : MockIRepositoryBase<IHistoryRepository, UserHistory>
 	{
 		public static Mock<IHistoryRepository> GetMock()
 		{
-			var collection = new List<History>() { };
+			var collection = new List<UserHistory>() { };
 
 			var mock = GetBaseMock(collection);
 

--- a/MojeWidelo_WebApi.UnitTests/Mocks/MockIHistoryRepository.cs
+++ b/MojeWidelo_WebApi.UnitTests/Mocks/MockIHistoryRepository.cs
@@ -1,0 +1,20 @@
+﻿using Contracts;
+using Entities.Models;
+using Moq;
+
+namespace MojeWidelo_WebApi.UnitTests.Mocks
+{
+	public class MockIHistoryRepository : MockIRepositoryBase<IHistoryRepository, History>
+	{
+		public static Mock<IHistoryRepository> GetMock()
+		{
+			var collection = new List<History>() { };
+
+			var mock = GetBaseMock(collection);
+
+			mock.Setup(m => m.AddToHistory(It.IsAny<string>(), It.IsAny<string>())).Callback(() => { });
+
+			return mock;
+		}
+	}
+}

--- a/MojeWidelo_WebApi.UnitTests/Mocks/MockIRepositoryWrapper.cs
+++ b/MojeWidelo_WebApi.UnitTests/Mocks/MockIRepositoryWrapper.cs
@@ -13,11 +13,13 @@ namespace MojeWidelo_WebApi.UnitTests.Mocks
 			var subscriptionsRepoMock = MockISubscriptionsRepository.GetMock();
 			var commentsRepoMock = MockICommentsRepository.GetMock();
 			var videosRepoMock = MockIVideosRepository.GetMock();
+			var historyRepoMock = MockIHistoryRepository.GetMock();
 
 			mock.Setup(m => m.UsersRepository).Returns(() => usersRepoMock.Object);
 			mock.Setup(m => m.SubscriptionsRepository).Returns(() => subscriptionsRepoMock.Object);
 			mock.Setup(m => m.CommentRepository).Returns(() => commentsRepoMock.Object);
 			mock.Setup(m => m.VideoRepository).Returns(() => videosRepoMock.Object);
+			mock.Setup(m => m.HistoryRepository).Returns(() => historyRepoMock.Object);
 
 			return mock;
 		}

--- a/MojeWidelo_WebApi/Controllers/UsersController.cs
+++ b/MojeWidelo_WebApi/Controllers/UsersController.cs
@@ -146,6 +146,8 @@ namespace MojeWidelo_WebApi.Controllers
 
 			user = await _repository.UsersRepository.Create(user);
 
+			await _repository.HistoryRepository.Create(new History(user.Id));
+
 			return StatusCode(StatusCodes.Status201Created, "Konto zostało utworzone pomyślnie.");
 		}
 

--- a/MojeWidelo_WebApi/Controllers/UsersController.cs
+++ b/MojeWidelo_WebApi/Controllers/UsersController.cs
@@ -146,7 +146,7 @@ namespace MojeWidelo_WebApi.Controllers
 
 			user = await _repository.UsersRepository.Create(user);
 
-			await _repository.HistoryRepository.Create(new History(user.Id));
+			await _repository.HistoryRepository.Create(new UserHistory(user.Id));
 
 			return StatusCode(StatusCodes.Status201Created, "Konto zostało utworzone pomyślnie.");
 		}

--- a/MojeWidelo_WebApi/Controllers/VideoController.cs
+++ b/MojeWidelo_WebApi/Controllers/VideoController.cs
@@ -124,6 +124,7 @@ namespace MojeWidelo_WebApi.Controllers
 			if (video.ProcessingProgress == ProcessingProgress.Ready)
 			{
 				video = await _repository.VideoRepository.UpdateViewCount(video.Id, 1);
+				await _repository.HistoryRepository.AddToHistory(GetUserIdFromToken(), video.Id);
 			}
 
 			var result = _mapper.Map<VideoMetadataDto>(video);

--- a/MojeWidelo_WebApi/Extensions/ServiceExtensions.cs
+++ b/MojeWidelo_WebApi/Extensions/ServiceExtensions.cs
@@ -35,6 +35,7 @@ namespace MojeWidelo_WebApi.Extensions
 			services.AddScoped<ICommentRepository, CommentRepository>();
 			services.AddScoped<ISubscriptionsRepository, SubscriptionsRepository>();
 			services.AddScoped<IPlaylistRepository, PlaylistRepository>();
+			services.AddScoped<IHistoryRepository, HistoryRepository>();
 		}
 
 		public static void ConfigureSwagger(this IServiceCollection services)

--- a/MojeWidelo_WebApi/appsettings.json
+++ b/MojeWidelo_WebApi/appsettings.json
@@ -14,7 +14,8 @@
     "ReactionCollectionName": "reactions",
     "CommentCollectionName": "comments",
     "SubscriptionCollectionName": "subscriptions",
-    "PlaylistCollectionName": "playlists"
+    "PlaylistCollectionName": "playlists",
+    "HistoryCollectionName": "history"
   },
   "Variables": {
     "VideoStorageLocation": "../VideoStorage",

--- a/Repository/HistoryRepository.cs
+++ b/Repository/HistoryRepository.cs
@@ -1,0 +1,20 @@
+﻿using Contracts;
+using Entities.Models;
+using Entities.Utils;
+using MongoDB.Driver;
+
+namespace Repository
+{
+	public class HistoryRepository : RepositoryBase<History>, IHistoryRepository
+	{
+		public HistoryRepository(IDatabaseSettings databaseSettings)
+			: base(databaseSettings, databaseSettings.HistoryCollectionName) { }
+
+		public async Task AddToHistory(string userId, string videoId)
+		{
+			var historyItem = new HistoryItem(videoId);
+			var update = Builders<History>.Update.Push<HistoryItem>(x => x.WatchedVideos, historyItem);
+			await Collection.UpdateOneAsync(x => x.Id == userId, update);
+		}
+	}
+}

--- a/Repository/HistoryRepository.cs
+++ b/Repository/HistoryRepository.cs
@@ -5,15 +5,14 @@ using MongoDB.Driver;
 
 namespace Repository
 {
-	public class HistoryRepository : RepositoryBase<History>, IHistoryRepository
+	public class HistoryRepository : RepositoryBase<UserHistory>, IHistoryRepository
 	{
 		public HistoryRepository(IDatabaseSettings databaseSettings)
 			: base(databaseSettings, databaseSettings.HistoryCollectionName) { }
 
 		public async Task AddToHistory(string userId, string videoId)
 		{
-			var historyItem = new HistoryItem(videoId);
-			var update = Builders<History>.Update.Push<HistoryItem>(x => x.WatchedVideos, historyItem);
+			var update = Builders<UserHistory>.Update.Push<HistoryItem>(x => x.WatchedVideos, new HistoryItem(videoId));
 			await Collection.UpdateOneAsync(x => x.Id == userId, update);
 		}
 	}

--- a/Repository/RepositoryWrapper.cs
+++ b/Repository/RepositoryWrapper.cs
@@ -10,6 +10,7 @@ namespace Repository
 		public ICommentRepository CommentRepository { get; }
 		public ISubscriptionsRepository SubscriptionsRepository { get; }
 		public IPlaylistRepository PlaylistRepository { get; }
+		public IHistoryRepository HistoryRepository { get; }
 
 		public RepositoryWrapper(
 			IUsersRepository usersRepository,
@@ -17,7 +18,8 @@ namespace Repository
 			IReactionRepository reactionRepository,
 			ICommentRepository commentRepository,
 			ISubscriptionsRepository subscriptionsRepository,
-			IPlaylistRepository playlistRepository
+			IPlaylistRepository playlistRepository,
+			IHistoryRepository historyRepository
 		)
 		{
 			UsersRepository = usersRepository;
@@ -26,6 +28,7 @@ namespace Repository
 			CommentRepository = commentRepository;
 			SubscriptionsRepository = subscriptionsRepository;
 			PlaylistRepository = playlistRepository;
+			HistoryRepository = historyRepository;
 		}
 	}
 }

--- a/mongo_scripts/createWatchHistory.js
+++ b/mongo_scripts/createWatchHistory.js
@@ -1,0 +1,16 @@
+const databaseName = 'mojeWideloDb';
+db = connect(`mongodb://localhost:27017/${databaseName}`);
+
+db.users.find().forEach(user => {
+    if (!db.history.countDocuments({ _id: user._id }, { limit: 1 }))
+        db.history.insertOne({
+            _id: user._id,
+            WatchedVideos: []
+        });
+});
+
+if (db.history.countDocuments() === db.users.countDocuments()) {
+    print('History successfully created.')
+}
+
+


### PR DESCRIPTION
dodałem historię wyszukiwania

każdy user ma swój obiekt historii w tabeli `history`. Po zarejestrowaniu dodaje się pusty wpis historii.
Dla każdego użytkownika który do tej pory jest w bazie trzeba taki pusty wpis zrobić. Napisałem skrypt do tego. Bez odpalenia go nic się nie stanie, żadnego błędu ale też historia nie będzie się zapisywać. 

Uruchomienie skryptu z konsoli:
``` mongosh --file mongo_scripts/createWatchHistory.js ```
na produkcyjnej bazie to wywołam przy mergowaniu

Historia ma swoje id, które jest jednocześnie id usera oraz listę obiektów HistoryItem

UWAGA: na razie, tak samo jak licznik wyświetleń, historia nabija się dość często, jest inny task na poprawienie tego

UWAGA2: do ustalenia co robimy z tymi tagami, gotowe do review ale nie do mergowania