### PR TITLE
Compress images while uploading them

### DIFF
--- a/Contracts/IRepositoryBase.cs
+++ b/Contracts/IRepositoryBase.cs
@@ -16,7 +16,6 @@ namespace Contracts
 		Task<T> Create(T entity);
 		Task<T> Update(string id, T entity);
 		Task Delete(string id);
-		Task<string> UploadImage(string fileName, string file);
-		Task<string> GetContentType(string id);
+		Task<string> UploadImage(string fileName, byte[] file);
 	}
 }

--- a/MojeWidelo_WebApi/Controllers/ImageController.cs
+++ b/MojeWidelo_WebApi/Controllers/ImageController.cs
@@ -23,17 +23,7 @@ namespace MojeWidelo_WebApi.Controllers
 				return StatusCode(StatusCodes.Status404NotFound, "Zdjęcie profilowe o podanym ID nie istnieje.");
 			}
 
-			string contentType;
-			try
-			{
-				contentType = await _repository.UsersRepository.GetContentType(id);
-			}
-			catch
-			{
-				return File(bytes, "");
-			}
-
-			return File(bytes, contentType);
+			return File(bytes, "image/png");
 		}
 
 		[HttpGet("thumbnail/{id}", Name = "GetThumbnail")]
@@ -47,17 +37,7 @@ namespace MojeWidelo_WebApi.Controllers
 				return StatusCode(StatusCodes.Status404NotFound, "Miniaturka o podanym ID nie istnieje.");
 			}
 
-			string contentType;
-			try
-			{
-				contentType = await _repository.VideoRepository.GetContentType(id);
-			}
-			catch
-			{
-				return File(bytes, "");
-			}
-
-			return File(bytes, contentType);
+			return File(bytes, "image/png");
 		}
 	}
 }

--- a/MojeWidelo_WebApi/Extensions/ServiceExtensions.cs
+++ b/MojeWidelo_WebApi/Extensions/ServiceExtensions.cs
@@ -172,6 +172,7 @@ namespace MojeWidelo_WebApi.Extensions
 			services.AddScoped<CommentManager>();
 			services.AddScoped<SubscriptionsManager>();
 			services.AddScoped<SearchManager>();
+			services.AddScoped<ImagesManager>();
 		}
 
 		public static void ConfigureVariables(this IServiceCollection services, ConfigurationManager configuration)

--- a/Repository/Managers/ImagesManager.cs
+++ b/Repository/Managers/ImagesManager.cs
@@ -1,0 +1,39 @@
+﻿namespace Repository.Managers
+{
+	public class ImagesManager
+	{
+		private const double _maxSize = 300.0;
+
+		public byte[] GetBytesFromBase64(string base64)
+		{
+			int startIdx = base64.IndexOf(',');
+			return Convert.FromBase64String(base64.Substring(startIdx + 1));
+		}
+
+		public byte[] CompressFile(byte[] bytes)
+		{
+			Image image;
+
+			using (MemoryStream ms = new MemoryStream(bytes, 0, bytes.Length))
+			{
+				image = Image.Load(ms);
+			}
+
+			int biggerDimension = image.Width > image.Height ? image.Width : image.Height;
+
+			if (biggerDimension > _maxSize)
+			{
+				double scale = _maxSize / biggerDimension;
+				int width = (int)(image.Width * scale);
+				int height = (int)(image.Height * scale);
+				image.Mutate(x => x.Resize(width, height));
+			}
+
+			using (MemoryStream ms = new MemoryStream())
+			{
+				image.SaveAsPng(ms);
+				return ms.ToArray();
+			}
+		}
+	}
+}

--- a/Repository/Repository.csproj
+++ b/Repository/Repository.csproj
@@ -14,6 +14,7 @@
 	  </PackageReference>
     <PackageReference Include="LinqKit" Version="1.2.4" />
     <PackageReference Include="MongoDB.Driver.GridFS" Version="2.19.1" />
+    <PackageReference Include="SixLabors.ImageSharp" Version="3.0.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Repository/RepositoryBase.cs
+++ b/Repository/RepositoryBase.cs
@@ -56,44 +56,11 @@ namespace Repository
 			await Collection.DeleteOneAsync(x => x.Id == id);
 		}
 
-		public async Task<string> UploadImage(string fileName, string file)
+		public async Task<string> UploadImage(string fileName, byte[] file)
 		{
-			int startIdx = file.IndexOf(',');
-			byte[] imgByteArray = Convert.FromBase64String(file.Substring(startIdx + 1));
-
-			startIdx = file.IndexOf(':');
-			int endIdx = file.IndexOf(';');
-
-			var id = await _bucket.UploadFromBytesAsync(
-				fileName,
-				imgByteArray,
-				new MongoDB.Driver.GridFS.GridFSUploadOptions
-				{
-					Metadata = new BsonDocument
-					{
-						{ "ContentType", file.Substring(startIdx + 1, endIdx - startIdx - 1) }
-					}
-				}
-			);
+			var id = await _bucket.UploadFromBytesAsync(fileName, file);
 
 			return id.ToString();
-		}
-
-		public async Task<string> GetContentType(string id)
-		{
-			var filter = Builders<GridFSFileInfo<ObjectId>>.Filter.Eq(x => x.Id, ObjectId.Parse(id));
-
-			using var cursor = await _bucket.FindAsync(filter);
-			var fileInfo = cursor.ToList().FirstOrDefault();
-
-			if (fileInfo == null)
-			{
-				throw new ArgumentNullException(null, nameof(fileInfo));
-			}
-
-			var contentType = fileInfo.Metadata.GetValue("ContentType").AsString;
-
-			return contentType;
 		}
 	}
 }

--- a/Repository/UsersRepository.cs
+++ b/Repository/UsersRepository.cs
@@ -6,13 +6,19 @@ using Entities.Utils;
 using MongoDB.Bson;
 using MongoDB.Driver;
 using MongoDB.Driver.GridFS;
+using Repository.Managers;
 
 namespace Repository
 {
 	public class UsersRepository : RepositoryBase<User>, IUsersRepository
 	{
-		public UsersRepository(IDatabaseSettings databaseSettings)
-			: base(databaseSettings, databaseSettings.UsersCollectionName) { }
+		private readonly ImagesManager _imagesManager;
+
+		public UsersRepository(IDatabaseSettings databaseSettings, ImagesManager imageManager)
+			: base(databaseSettings, databaseSettings.UsersCollectionName)
+		{
+			_imagesManager = imageManager;
+		}
 
 		public async Task<User> FindUserByEmail(string email)
 		{
@@ -26,7 +32,8 @@ namespace Repository
 			if (userDto.AvatarImage != null)
 			{
 				user.AvatarImage = "api/avatar/";
-				user.AvatarImage += await UploadImage(userDto.Nickname += " - avatar", userDto.AvatarImage);
+				var bytes = _imagesManager.CompressFile(_imagesManager.GetBytesFromBase64(userDto.AvatarImage));
+				user.AvatarImage += await UploadImage(userDto.Nickname += " - avatar", bytes);
 			}
 		}
 

--- a/Repository/VideoRepository.cs
+++ b/Repository/VideoRepository.cs
@@ -15,11 +15,17 @@ namespace Repository
 	public class VideoRepository : RepositoryBase<VideoMetadata>, IVideoRepository
 	{
 		readonly VideoManager videoManager;
+		private readonly ImagesManager _imagesManager;
 
-		public VideoRepository(IDatabaseSettings databaseSettings, VideoManager videoManager)
+		public VideoRepository(
+			IDatabaseSettings databaseSettings,
+			VideoManager videoManager,
+			ImagesManager imagesManager
+		)
 			: base(databaseSettings, databaseSettings.VideoCollectionName)
 		{
 			this.videoManager = videoManager;
+			_imagesManager = imagesManager;
 		}
 
 		public async Task ChangeVideoProcessingProgress(string id, ProcessingProgress progress)
@@ -114,7 +120,8 @@ namespace Repository
 			if (videoDto.Thumbnail != null)
 			{
 				video.Thumbnail = "api/thumbnail/";
-				video.Thumbnail += await UploadImage(videoDto.Title + " - thumbnail", videoDto.Thumbnail);
+				var bytes = _imagesManager.CompressFile(_imagesManager.GetBytesFromBase64(videoDto.Thumbnail));
+				video.Thumbnail += await UploadImage(videoDto.Title + " - thumbnail", bytes);
 			}
 		}
 


### PR DESCRIPTION
drugi smaczniutki PRek - dlaczego taki smaczny 😋

przy wrzucaniu zdjęcia jest ono kompresowane (maksymalny rozmiar WIĘKSZEGO wymiaru jest skalowany do 300px, drugi tak żeby zachować proporcje). dodatkowo wszystkie zdjęcia są trzymane jako png - wcześniej były trzymane tak jak wrzucone. program wykrywa niepoprawne zdjęcia (nie wrzucisz pliku tekstowego o rozszerzeniu .png). użyłem jakiejś magicznej libki imagesharp, bo image z microsoftu działa tylko na windowsie (a mianowicie zapisywanie ze streamu do image - kto by się spodziewał że produkt microsoftu działa jak gówno ;p). nie testowałem na ubuntu, mam nadzieję że zadziała hehe, pisali że cross-platform.

na koniec - jak testować? no wrzućcie duże zdjęcie jako awatar, milionxmilion pixeli, i potem ono powinno być pobierane w mig mig pyk pyk

same innowacje, najwyższa klasa, pozdrawiam