### PR TITLE
Add scripts for creating and restoring db backups

### DIFF
--- a/mongo_scripts/create_backup.sh
+++ b/mongo_scripts/create_backup.sh
@@ -1,0 +1,31 @@
+#!/bin/bash
+
+usage()
+{
+   echo ""
+   echo "Usage: $0 [ -n user_friendly_backup_name -c collection_name]"
+   exit 1 
+}
+
+while getopts ":n:c:" opt; do
+    case $opt in
+        n) name="_$OPTARG" ;;
+        c) collection_name=$OPTARG ;;
+        \?) usage ;;
+        :) usage ;;
+    esac
+done
+
+database_name=mojeWideloDb_Production
+backup_name="$HOME"/io2/mongo_backups/$(date +"%Y_%m_%d_%H_%M_%S")"$name"
+video_storage="$HOME"/production/video-storage
+
+mongodump --out="$backup_name" --db="$database_name" --collection="$collection_name"
+
+echo ""
+echo "Copying video storage..."
+cp -R "$video_storage" "$backup_name"
+echo "Video storage successfully copied."
+
+echo ""
+echo "Backup successfully created in: $backup_name"

--- a/mongo_scripts/restore_backup.sh
+++ b/mongo_scripts/restore_backup.sh
@@ -1,0 +1,36 @@
+#!/bin/bash
+
+usage()
+{
+   echo ""
+   echo "Usage: $0 -d backup_directory"
+   exit 1 
+}
+
+while getopts "d:" opt; do
+    case $opt in
+        d) dir_name="$OPTARG" ;;
+        \?) usage ;;
+        :) usage ;;
+    esac
+done
+
+if [ -z "$dir_name" ]; then
+    usage
+fi
+
+echo $dir_name
+
+storage=video-storage
+production_video_storage="$HOME"/production/"$storage"
+
+mongorestore "$dir_name"
+
+echo ""
+echo "Copying video storage..."
+rm -rf "$production_video_storage"
+cp -R "$dir_name/$storage" "$production_video_storage"
+echo "Video storage successfully copied."
+
+echo ""
+echo "Backup successfully restored."


### PR DESCRIPTION
## Backup bazy danych
Skrypty znajdują się w folderze `mongo_scripts`.

### Tworzenie backup'u bazy danych
Skrypt `create_backup.sh` tworzy backup produkcyjnej bazy danych `mojeWideloDb_Production` oraz zawartości folderu z filmami `~/production/video-storage`.
Backup tworzy się w folderze `/home/ubuntu/io2/mongo_backups/data_utworzenia`. Folder `data_utworzenia` może zawierać sufix, który mógł (ale nie musiał) zostać przekazany podczas tworzenia backupu (dla czytelności).

#### Przykłady wywołania:
`./create_backup.sh`
`./create_backup.sh -n test`
`./create_backup.sh -n test -c playlists` - tworzy kopię tylko podanej kolekcji (ale filmy z `video-storage` zawsze są kopiowane!)

### Przywracanie backup'u bazy danych
Skrypt `restore_backup.sh` przywraca kopię produkcyjnej bazy danych oraz zawartości folderu z filmami.
Przy wywołaniu skryptu wymagane jest jawne podanie folderu utworzonego podczas tworzenia backup'u z flagą `-d`.

#### Przykład wywołania:
`./restore_backup.sh -d ~/io2/mongo_backups/2023_06_06_16_25_45_test/`