### PR TITLE
Add logic for administrator

### DIFF
--- a/Contracts/IPlaylistRepository.cs
+++ b/Contracts/IPlaylistRepository.cs
@@ -4,7 +4,7 @@ namespace Contracts
 {
 	public interface IPlaylistRepository : IRepositoryBase<Playlist>
 	{
-		Task<IEnumerable<Playlist>> GetPlaylistByUserId(string id, string callerID);
+		Task<IEnumerable<Playlist>> GetPlaylistByUserId(string id, User caller);
 		Task<IEnumerable<Playlist>> GetAllVisiblePlaylists(string userId);
 	}
 }

--- a/MojeWidelo_WebApi.UnitTests/Mocks/MockIPlaylistRepository.cs
+++ b/MojeWidelo_WebApi.UnitTests/Mocks/MockIPlaylistRepository.cs
@@ -35,13 +35,17 @@ namespace MojeWidelo_WebApi.UnitTests.Mocks
 
 			var mock = GetBaseMock(collection);
 
-			mock.Setup(m => m.GetPlaylistByUserId(It.IsAny<string>(), It.IsAny<string>()))
+			mock.Setup(m => m.GetPlaylistByUserId(It.IsAny<string>(), It.IsAny<User>()))
 				.ReturnsAsync(
-					(string id, string callerID) =>
+					(string id, User caller) =>
 						collection.Where(
 							x =>
 								x.AuthorId == id
-								&& (x.Visibility == PlaylistVisibility.Public || x.AuthorId == callerID)
+								&& (
+									x.Visibility == PlaylistVisibility.Public
+									|| x.AuthorId == caller.Id
+									|| caller.UserType == UserType.Administrator
+								)
 						)
 				);
 

--- a/MojeWidelo_WebApi.UnitTests/Tests/Repositories/PlaylistRepositoryTests.cs
+++ b/MojeWidelo_WebApi.UnitTests/Tests/Repositories/PlaylistRepositoryTests.cs
@@ -9,8 +9,10 @@ namespace MojeWidelo_WebApi.UnitTests.Tests.Repositories
 		[InlineData("6429a1ee0d48bf254e17eaf7", "6429a1ee0d48bf254e17eaf7")]
 		public async Task GetPlaylistByUserIdOwnerTest(string id, string callerId)
 		{
-			var respository = MockIPlaylistRepository.GetMock().Object;
-			var result = await respository.GetPlaylistByUserId(id, callerId);
+			var playlistRepository = MockIPlaylistRepository.GetMock().Object;
+			var usersRepository = MockIUsersRepository.GetMock().Object;
+			var caller = await usersRepository.GetById(callerId);
+			var result = await playlistRepository.GetPlaylistByUserId(id, caller);
 
 			Assert.NotNull(result);
 			Assert.IsAssignableFrom<IEnumerable<Playlist>>(result);
@@ -21,8 +23,10 @@ namespace MojeWidelo_WebApi.UnitTests.Tests.Repositories
 		[InlineData("6429a1ee0d48bf254e17eaf7", "64390ed1d3768498801aa03f")]
 		public async Task GetPlaylistByUserIdNotOwnerTest(string id, string callerId)
 		{
-			var respository = MockIPlaylistRepository.GetMock().Object;
-			var result = await respository.GetPlaylistByUserId(id, callerId);
+			var playlistRepository = MockIPlaylistRepository.GetMock().Object;
+			var usersRepository = MockIUsersRepository.GetMock().Object;
+			var caller = await usersRepository.GetById(callerId);
+			var result = await playlistRepository.GetPlaylistByUserId(id, caller);
 
 			Assert.NotNull(result);
 			Assert.IsAssignableFrom<IEnumerable<Playlist>>(result);

--- a/MojeWidelo_WebApi/Controllers/SearchController.cs
+++ b/MojeWidelo_WebApi/Controllers/SearchController.cs
@@ -46,6 +46,7 @@ namespace MojeWidelo_WebApi.Controllers
 			var callerId = GetUserIdFromToken();
 
 			var users = await _repository.UsersRepository.GetAll();
+			users = users.Where(x => x.UserType != UserType.Administrator);
 			var usersDto = _mapper.Map<IEnumerable<UserDto>>(users);
 
 			var videos = await _repository.VideoRepository.GetAllVisibleVideos(callerId);

--- a/MojeWidelo_WebApi/Controllers/UsersController.cs
+++ b/MojeWidelo_WebApi/Controllers/UsersController.cs
@@ -165,8 +165,9 @@ namespace MojeWidelo_WebApi.Controllers
 		[ServiceFilter(typeof(ObjectIdValidationFilter))]
 		public async Task<IActionResult> DeleteUser([Required] string id)
 		{
-			var user = await _repository.UsersRepository.GetById(id);
-			if (user.UserType != UserType.Administrator)
+			var senderId = GetUserIdFromToken();
+			var user = await _repository.UsersRepository.GetById(senderId);
+			if (user.UserType != UserType.Administrator && senderId != id)
 			{
 				return StatusCode(StatusCodes.Status403Forbidden, "Nie masz uprawnień do usunięcia konta.");
 			}

--- a/MojeWidelo_WebApi/Controllers/UsersController.cs
+++ b/MojeWidelo_WebApi/Controllers/UsersController.cs
@@ -136,6 +136,11 @@ namespace MojeWidelo_WebApi.Controllers
 		[ServiceFilter(typeof(ModelValidationFilter))]
 		public async Task<IActionResult> RegisterUser([FromBody] RegisterRequestDto registerDto)
 		{
+			if (registerDto.UserType == UserType.Administrator)
+			{
+				return StatusCode(StatusCodes.Status403Forbidden, "Nie można utworzyć konta będącego administratorem.");
+			}
+
 			var existingUser = await _repository.UsersRepository.FindUserByEmail(registerDto.Email);
 			if (existingUser != null)
 				return StatusCode(StatusCodes.Status409Conflict, "Konto z podanym emailem już istnieje.");
@@ -160,6 +165,11 @@ namespace MojeWidelo_WebApi.Controllers
 		[ServiceFilter(typeof(ObjectIdValidationFilter))]
 		public async Task<IActionResult> DeleteUser([Required] string id)
 		{
+			var user = await _repository.UsersRepository.GetById(id);
+			if (user.UserType != UserType.Administrator)
+			{
+				return StatusCode(StatusCodes.Status403Forbidden, "Nie masz uprawnień do usunięcia konta.");
+			}
 			await _repository.UsersRepository.Delete(id);
 			return StatusCode(StatusCodes.Status200OK, "Użytkownik został usunięty pomyślnie.");
 		}

--- a/MojeWidelo_WebApi/Mapper/UserProfile.cs
+++ b/MojeWidelo_WebApi/Mapper/UserProfile.cs
@@ -16,6 +16,14 @@ namespace MojeWidelo_WebApi.Mapper
 							user =>
 								user.UserType == Entities.Enums.UserType.Creator ? (int?)user.SubscriptionsCount : null
 						)
+				)
+				.ForMember(
+					user => user.AccountBalance,
+					opt =>
+						opt.MapFrom(
+							user =>
+								user.UserType == Entities.Enums.UserType.Creator ? (decimal?)user.AccountBalance : null
+						)
 				);
 			CreateMap<UpdateUserDto, User>();
 

--- a/Repository/PlaylistRepository.cs
+++ b/Repository/PlaylistRepository.cs
@@ -11,10 +11,18 @@ namespace Repository
 		public PlaylistRepository(IDatabaseSettings databaseSettings)
 			: base(databaseSettings, databaseSettings.PlaylistCollectionName) { }
 
-		public async Task<IEnumerable<Playlist>> GetPlaylistByUserId(string id, string callerID)
+		public async Task<IEnumerable<Playlist>> GetPlaylistByUserId(string id, User caller)
 		{
 			return await Collection
-				.Find(x => x.AuthorId == id && (x.Visibility == PlaylistVisibility.Public || x.AuthorId == callerID))
+				.Find(
+					x =>
+						x.AuthorId == id
+						&& (
+							x.Visibility == PlaylistVisibility.Public
+							|| x.AuthorId == caller.Id
+							|| caller.UserType == UserType.Administrator
+						)
+				)
 				.ToListAsync();
 		}
 


### PR DESCRIPTION
Dodanie logiki do admina

pytania które zadałem na pv Mikołajowi i mamy się nad nimi zastanowić (wrzucam tu, jak ktoś chce się włączyć do dyskusji, to pv):
1. czy admin może edytować playlistę (imo nie, po co)
2. czy admin może usunąć film z playlisty (imo nie, może usunąć playkę, ale po co usuwać film z playki? to wsm to samo co w 1.)
3. czy w wyszukiwaniu adminowi powinny pokazywać się prywatne filmy, prywatne playki, czy tylko jak wejdzie się na profil użytkownika? (tutaj nwm co myśleć, więc na razie nie zaimplementowałem, wymagałoby przerobienia twoich funkcji w Search)
4. czy w registerUser nie powinienem sprawdzać czy ktoś nie próbuje zostać adminem? XD przecież można by wtedy z postmana się adminem kurwa stawać, to jest błąd security taki, że głowa mała (na razie to dodałem, odnieś się pls)
5. czy jest gdzieś opcja żeby usunąć własne konto? bo na razie endpoint deleteUser wygląda tak, że tylko id podajemy, więc znowu w postmanie może se ktokolwiek usunąć kogokolwiek xdd (na razie dodaję, że tylko admin może to użyć, nie będzie można usunąć nawet własnego konta)
6. w GetAllVideos to samo co w 3.
7. w GetVideosSubscribed to samo co w 3.

eldon.